### PR TITLE
Plaintext representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # ostis-linguistics
 Lingusitic knowledge base for natural language processing subsystems based on OSTIS
+
+## plain-text-interface
+UI component of plain text representation for Open Semantic Technologies for Intelligent Systems (OSTIS)
+
+Please find more info in example project <a href="https://github.com/MikhailSadovsky/ostis-UI-component-sample/wiki">wiki</a>

--- a/kb/ui/menu/ui_main_menu.scs
+++ b/kb/ui/menu/ui_main_menu.scs
@@ -8,5 +8,6 @@ ui_main_menu
     {
 	    ui_menu_na_view_kb_extended;
         ui_menu_na_keynodes;
-        ui_menu_na_natural_language_texts
+        ui_menu_na_natural_language_texts;
+	    ui_menu_na_example_commands
     };;

--- a/kb/ui/menu/ui_menu_na_example_commands.scs
+++ b/kb/ui/menu/ui_menu_na_example_commands.scs
@@ -1,0 +1,13 @@
+ui_menu_na_example_commands
+<- ui_user_command_class_noatom;
+=> nrel_main_idtf:
+	[Примеры команд] (* <- lang_ru;; *);
+	[Command examples] (* <- lang_en;; *);
+
+<= nrel_ui_commands_decomposition:
+	{
+		ui_menu_subdividing_search;
+		ui_menu_message_classification;
+		ui_menu_plain_text_representation
+
+	};;

--- a/plain-text-interface/Gruntfile.js
+++ b/plain-text-interface/Gruntfile.js
@@ -1,0 +1,274 @@
+module.exports = function(grunt) {
+
+    var githubDirPath = 'components/github/';
+    var htmlDirPath = 'components/html/';
+    var scgDirPath = 'components/scg/';
+    var scsDirPath = 'components/scs/';
+    var plainTextDirPath = 'components/plain_text/';
+    var webCoreCompPath = 'client/js/';
+    var clientJsDirPath = 'client/static/components/js/';
+    var clientCssDirPath = 'client/static/components/css/';
+    var clientHtmlDirPath = 'client/static/components/html/';
+    var clientImgDirPath = 'client/static/components/images/';
+
+    grunt.initConfig({
+        concat: {
+            webcore: {
+                src: [webCoreCompPath + 'Utils/sc_keynodes.js',
+                      webCoreCompPath + 'Utils/utils.js',
+                      webCoreCompPath + 'Utils/sc_helper.js',
+                      webCoreCompPath + 'Utils/stringview.js',
+                      webCoreCompPath + 'Utils/cache.js',
+                      webCoreCompPath + 'Utils/sctp.js',
+                      webCoreCompPath + 'Utils/fqueue.js',
+                      webCoreCompPath + 'Utils/binary.js',
+                      webCoreCompPath + 'Utils/triples.js',
+                      webCoreCompPath + 'Utils/sc_link_helper.js',
+                      webCoreCompPath + 'Core/namespace.js',
+                      webCoreCompPath + 'Core/debug.js',
+                      webCoreCompPath + 'Core/main.js',
+                      webCoreCompPath + 'Core/server.js',
+                      webCoreCompPath + 'Core/arguments.js',
+                      webCoreCompPath + 'Core/componentsandbox.js',
+                      webCoreCompPath + 'Core/translation.js',
+                      webCoreCompPath + 'Core/componentmanger.js',
+                      webCoreCompPath + 'Core/eventmanager.js',
+                      webCoreCompPath + 'Ui/namespace.js',
+                      webCoreCompPath + 'Ui/menu.js',
+                      webCoreCompPath + 'Ui/langpanel.js',
+                      webCoreCompPath + 'Ui/locker.js',
+                      webCoreCompPath + 'Ui/core.js',
+                      webCoreCompPath + 'Ui/searchpanel.js',
+                      webCoreCompPath + 'Ui/KeyboardHandler.js',
+                      webCoreCompPath + 'Ui/taskpanel.js',
+                      webCoreCompPath + 'Ui/argumentspanel.js',
+                      webCoreCompPath + 'Ui/windowmanager.js',
+                      webCoreCompPath + 'Ui/OpenComponentHandler.js',
+                      webCoreCompPath + 'Ui/userpanel.js',
+                      webCoreCompPath + 'Ui/expertmodepanel.js',
+                      webCoreCompPath + 'Ui/ExpertModeHandler.js',
+                ],
+                dest: clientJsDirPath + 'sc-web-core.js',
+            },
+            github: {
+                src: [githubDirPath + 'src/*.js'],
+                dest: githubDirPath + 'static/components/js/github/github.js'
+            },
+            html: {
+                src: [htmlDirPath + 'src/*.js'],
+                dest: htmlDirPath + 'static/components/js/html/html.js'
+            },
+            scg: {
+                src: [
+                      scgDirPath + '/src/gwf-file-creater.js',
+                      scgDirPath + '/src/gwf-file-loader.js',
+                      scgDirPath + '/src/gwf-model-objects.js',
+                      scgDirPath + '/src/gwf-object-info-reader.js',
+                      scgDirPath + '/src/scg-object-builder.js',
+                      scgDirPath + '/src/scg.js',
+                      scgDirPath + '/src/scg-debug.js',
+                      scgDirPath + '/src/scg-math.js',
+                      scgDirPath + '/src/scg-model-objects.js',
+                      scgDirPath + '/src/scg-alphabet.js',
+                      scgDirPath + '/src/scg-render.js',
+                      scgDirPath + '/src/scg-scene.js',
+                      scgDirPath + '/src/scg-layout.js',
+                      scgDirPath + '/src/scg-tree.js',
+                      scgDirPath + '/src/scg-struct.js',
+                      scgDirPath + '/src/scg-object-creator.js',
+                      scgDirPath + '/src/scg-component.js',
+                      scgDirPath + '/src/listener/*.js',
+                      scgDirPath + '/src/command/append-object.js',
+                      scgDirPath + '/src/command/command-manager.js',
+                      scgDirPath + '/src/command/create-node.js',
+                      scgDirPath + '/src/command/create-edge.js',
+                      scgDirPath + '/src/command/create-bus.js',
+                      scgDirPath + '/src/command/create-contour.js',
+                      scgDirPath + '/src/command/create-link.js',
+                      scgDirPath + '/src/command/change-idtf.js',
+                      scgDirPath + '/src/command/change-content.js',
+                      scgDirPath + '/src/command/change-type.js',
+                      scgDirPath + '/src/command/delete-objects.js',
+                      scgDirPath + '/src/command/move-object.js',
+                      scgDirPath + '/src/command/move-line-point.js',
+                      scgDirPath + '/src/command/get-node-from-memory.js',
+                      scgDirPath + '/src/command/wrapper-command.js'],
+                dest: scgDirPath + 'static/components/js/scg/scg.js'
+            },
+            scs: {
+                src: [scsDirPath + 'src/scs.js',
+                      scsDirPath + 'src/scs-viewer.js',
+                      scsDirPath + 'src/scs-output.js',
+                      scsDirPath + 'src/scs-types.js',
+                      scsDirPath + 'src/scn-output.js',
+                      scsDirPath + 'src/scn-tree.js',
+                      scsDirPath + 'src/scn-highlighter.js',
+                      scsDirPath + 'src/scs-expert-mode.js',
+                      scsDirPath + 'src/scs-component.js'],
+                dest: scsDirPath + 'static/components/js/scs/scs.js'
+            },
+            plain_text: {
+                src: [plainTextDirPath + 'src/plain_text-common.js',
+                      plainTextDirPath + 'src/plain_text-component.js',
+                      plainTextDirPath + 'src/plain_text-paintPanel.js'
+                ],
+                dest: plainTextDirPath + 'static/components/js/plain_text/plain_text.js'
+            },
+        },
+        copy: {
+            githubJs: {
+                cwd: githubDirPath + 'static/components/js/github/',
+                src: 'github.js',
+                dest: clientJsDirPath + 'github/',
+                expand: true,
+                flatten: true
+            },
+            htmlJs: {
+                cwd: htmlDirPath + 'static/components/js/html/',
+                src: 'html.js',
+                dest: clientJsDirPath + 'html/',
+                expand: true,
+                flatten: true
+            },
+            scgJs: {
+                cwd: scgDirPath + 'static/components/js/scg/',
+                src: 'scg.js',
+                dest: clientJsDirPath + 'scg/',
+                expand: true,
+                flatten: true
+            },
+            scsJs: {
+                cwd: scsDirPath + 'static/components/js/scs/',
+                src: 'scs.js',
+                dest: clientJsDirPath + 'scs/',
+                expand: true,
+                flatten: true
+            },
+            plainTextJs: {
+                cwd: plainTextDirPath + 'static/components/js/plain_text/',
+                src: 'plain_text.js',
+                dest: clientJsDirPath + 'plain_text/',
+                expand: true,
+                flatten: true
+            },
+            githubCss: {
+                cwd: githubDirPath + 'static/components/css/',
+                src: 'github.css',
+                dest: clientCssDirPath,
+                expand: true,
+                flatten: true
+            },
+            htmlCss: {
+                cwd: htmlDirPath + 'static/components/css/',
+                src: 'html.css',
+                dest: clientCssDirPath,
+                expand: true,
+                flatten: true
+            },
+            scgCss: {
+                cwd: scgDirPath + 'static/components/css/',
+                src: 'scg.css',
+                dest: clientCssDirPath,
+                expand: true,
+                flatten: true
+            },
+            scsCss: {
+                cwd: scsDirPath + 'static/components/css/',
+                src: 'scs.css',
+                dest: clientCssDirPath,
+                expand: true,
+                flatten: true
+            },
+            scgHtml: {
+                cwd: scgDirPath + 'static/components/html/',
+                src: ['**/*.html'],
+                dest: clientHtmlDirPath,
+                expand: true,
+                flatten: true
+            },
+            htmlImg: {
+                cwd: htmlDirPath + 'static/components/images/html/',
+                src: '**/*.png',
+                dest: clientImgDirPath + 'html/',
+                expand: true,
+                flatten: true
+            },
+            scgImg: {
+                cwd: scgDirPath + 'static/components/images/scg/',
+                src: '*.png',
+                dest: clientImgDirPath + 'scg/',
+                expand: true,
+                flatten: true
+            },
+            scgImgAlphabet: {
+                cwd: scgDirPath + 'static/components/images/scg/alphabet/',
+                src: '*.png',
+                dest: clientImgDirPath + 'scg/alphabet',
+                expand: true,
+                flatten: true
+            }
+        },
+        watch: {
+            core: {
+                files: webCoreCompPath + '**',
+                tasks: ['concat:webcore'],
+            },
+            githubJs: {
+                files: githubDirPath + 'src/**',
+                tasks: ['concat:github', 'copy:githubJs'],
+            },
+            htmlJs: {
+                files: htmlDirPath + 'src/**',
+                tasks: ['concat:html', 'copy:htmlJs'],
+            },
+            scgJs: {
+                files: scgDirPath + 'src/**',
+                tasks: ['concat:scg', 'copy:scgJs'],
+            },
+            scsJs: {
+                files: scsDirPath + 'src/**',
+                tasks: ['concat:scs', 'copy:scsJs'],
+            },
+            plainTextJs: {
+                files: plainTextDirPath + 'src/**',
+                tasks: ['concat:plain_text', 'copy:plainTextJs'],
+            },
+            githubCss: {
+                files: githubDirPath + 'static/components/css/**',
+                tasks: ['copy:githubCss'],
+            },
+            htmlCss: {
+                files: htmlDirPath + 'static/components/css/**',
+                tasks: ['copy:htmlCss'],
+            },
+            scgCss: {
+                files: scgDirPath + 'static/components/css/**',
+                tasks: ['copy:scgCss'],
+            },
+            scsCss: {
+                files: scsDirPath + 'static/components/css/**',
+                tasks: ['copy:scsCss'],
+            },
+            scgHtml: {
+                files: [scgDirPath + 'static/components/html/**'],
+                tasks: ['copy:scgHtml'],
+            },
+            htmlImg: {
+                files: [htmlDirPath + 'static/components/images/html/**',],
+                tasks: ['copy:htmlImg'],
+            },
+            scgImg: {
+                files: [scgDirPath + 'static/components/images/scg/**'],
+                tasks: ['copy:scgImg', 'copy:scgImgAlphabet'],
+            },
+        },
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-concat');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
+    grunt.registerTask('default', ['concat', 'copy', 'watch']);
+    grunt.registerTask('build', ['concat', 'copy']);
+
+};

--- a/plain-text-interface/components.html
+++ b/plain-text-interface/components.html
@@ -1,0 +1,19 @@
+<link rel="stylesheet" type="text/css" href="/static/components/css/scg.css" />
+<link rel="stylesheet" type="text/css" href="/static/components/css/scs.css" />
+<link rel="stylesheet" type="text/css" href="/static/components/css/html.css" />
+<link rel="stylesheet" type="text/css" href="/static/components/css/github.css" />
+
+
+<script type="text/javascript" charset="utf-8" src="/static/components/js/sc-web-core.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/scs/scs.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/scg/scg.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/image/image.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/txt/txt.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/html/html.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/youtube/youtubelink.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/map/googlemaplink.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/github/github.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/pdf/pdf.js"></script>
+<script type="text/javascript" charset="utf-8" src="/static/components/js/plain_text/plain_text.js"></script>
+
+<script type="text/javascript" charset="utf-8" src="/static/components/js/file-saver/FileSaver.min.js"></script>

--- a/plain-text-interface/kb/formats.scs
+++ b/plain-text-interface/kb/formats.scs
@@ -1,0 +1,213 @@
+format 
+<- sc_node_not_relation;
+=> nrel_main_idtf: 
+	[формат] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format] 
+	(* 
+	<- lang_en;; 
+	*);;
+
+
+// ======= json =======
+
+// --- scg ---
+format_scg_json
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат scg (json)] 
+	(* 
+	<- lang_ru;;
+	 *);
+=> nrel_main_idtf: 
+	[format scg (json)] 
+	(* 
+	<- lang_en;;
+	*);
+=> nrel_mimetype:
+	[application/json];;
+
+// --- scn ---
+format_scn_json
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат scn (json)] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format scn (json)] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[application/json];;
+
+// --- scs ---
+format_scs_json 
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат scs (json)] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format scs (json)] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	 [application/json];;
+
+// ======= internet ========
+
+// --- google map ---
+format_googlemaplink
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат googlemaplink] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format googlemaplink] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[text/plain];;
+
+// --- html ---
+format_html 
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат html] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format html] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[text/html];;
+
+// --- youtube ---
+format_youtubelink
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат youtube]
+	(*
+	<- lang_ru;;
+	*);
+=> nrel_main_idtf: 
+	[format youtube] 
+	(*
+	<- lang_en;;
+	*);
+=> nrel_mimetype:
+	[text/html];;
+
+// ======= text =======
+
+// --- txt ---
+format_txt
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат txt] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format txt] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[text/plain];;
+
+
+// ======= Images ========
+
+// --- png ---
+format_png
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат png] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format png] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[image/png];;
+
+// --- link to github sources ---
+format_github_source_link
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат github source] 
+	(* 
+	<- lang_ru;;
+	 *);
+=> nrel_main_idtf: 
+	[format github source] 
+	(* 
+	<- lang_en;;
+	*);
+=> nrel_mimetype:
+	[text/plain];;
+
+// ======== PDF ========
+format_pdf
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf: 
+	[формат pdf] 
+	(* 
+	<- lang_ru;; 
+	*);
+=> nrel_main_idtf: 
+	[format pdf] 
+	(* 
+	<- lang_en;; 
+	*);
+=> nrel_mimetype:
+	[application/pdf];;
+
+// ===== Plain text ====
+format_plain_text
+<- sc_node_not_relation;
+<- format;
+=> nrel_main_idtf:
+[формат plain text ПИ]
+(*
+<- lang_ru;;
+*);
+=> nrel_main_idtf:
+[format plain text UI]
+(*
+<- lang_en;;
+*);
+=> nrel_mimetype:
+[text/html];;
+
+binary_types
+<- sc_node_not_relation;
+-> binary_float; binary_int8; binary_int16; binary_int32; binary_int64;;

--- a/plain-text-interface/kb/ui_external_languages.scs
+++ b/plain-text-interface/kb/ui_external_languages.scs
@@ -1,0 +1,3 @@
+ui_external_languages <- sc_node_not_relation;;
+
+ui_external_languages -> scg_code; scs_code; plain_text;;

--- a/plain-text-interface/plain_text/build.json
+++ b/plain-text-interface/plain_text/build.json
@@ -1,0 +1,11 @@
+{
+     "sources": [
+        
+        "src/plain_text-common.js",
+        "src/plain_text-paintPanel.js"
+    ],
+
+    "component": "src/plain_text-component.js",
+
+    "target": "static/components/js/plain_text/plain_text.js"
+}

--- a/plain-text-interface/plain_text/src/plain_text-common.js
+++ b/plain-text-interface/plain_text/src/plain_text-common.js
@@ -1,0 +1,10 @@
+var Example = {};
+
+function extend(child, parent) {
+    var F = function () {
+    };
+    F.prototype = parent.prototype;
+    child.prototype = new F();
+    child.prototype.constructor = child;
+    child.superclass = parent.prototype;
+}

--- a/plain-text-interface/plain_text/src/plain_text-component.js
+++ b/plain-text-interface/plain_text/src/plain_text-component.js
@@ -1,0 +1,94 @@
+/**
+ * Example component.
+ */
+Example.DrawComponent = {
+    ext_lang: 'plain_text',
+    formats: ['format_plain_text'],
+    struct_support: true,
+    factory: function (sandbox) {
+        return new Example.DrawWindow(sandbox);
+    }
+};
+
+Example.DrawWindow = function (sandbox) {
+    this.sandbox = sandbox;
+    this.paintPanel = new Example.PaintPanel(this.sandbox.container);
+    this.paintPanel.init();
+    this.recieveData = function (data) {
+        console.log("in recieve data" + data);
+    };
+
+    var scElements = {};
+
+    function drawAllElements() {
+        var dfd = new jQuery.Deferred();
+       // for (var addr in scElements) {
+            jQuery.each(scElements, function(j, val){
+                var obj = scElements[j];
+                if (!obj || obj.translated) return;
+// check if object is an arc
+                if (obj.data.type & sc_type_arc_pos_const_perm) {
+                    var begin = obj.data.begin;
+                    var end = obj.data.end;
+                    // logic for component update should go here
+                }
+
+        });
+        SCWeb.ui.Locker.hide();
+        dfd.resolve();
+        return dfd.promise();
+    }
+
+// resolve keynodes
+    var self = this;
+    this.needUpdate = false;
+    this.requestUpdate = function () {
+        var updateVisual = function () {
+// check if object is an arc
+            var dfd1 = drawAllElements();
+            dfd1.done(function (r) {
+                return;
+            });
+
+
+/// @todo: Don't update if there are no new elements
+            window.clearTimeout(self.structTimeout);
+            delete self.structTimeout;
+            if (self.needUpdate)
+                self.requestUpdate();
+            return dfd1.promise();
+        };
+        self.needUpdate = true;
+        if (!self.structTimeout) {
+            self.needUpdate = false;
+            SCWeb.ui.Locker.show();
+            self.structTimeout = window.setTimeout(updateVisual, 1000);
+        }
+    }
+    
+    this.eventStructUpdate = function (added, element, arc) {
+        window.sctpClient.get_arc(arc).done(function (r) {
+            var addr = r[1];
+            window.sctpClient.get_element_type(addr).done(function (t) {
+                var type = t;
+                var obj = new Object();
+                obj.data = new Object();
+                obj.data.type = type;
+                obj.data.addr = addr;
+                if (type & sc_type_arc_mask) {
+                    window.sctpClient.get_arc(addr).done(function (a) {
+                        obj.data.begin = a[0];
+                        obj.data.end = a[1];
+                        scElements[addr] = obj;
+                        self.requestUpdate();
+                    });
+                }
+            });
+        });
+    };
+// delegate event handlers
+    this.sandbox.eventDataAppend = $.proxy(this.receiveData, this);
+    this.sandbox.eventStructUpdate = $.proxy(this.eventStructUpdate, this);
+    this.sandbox.updateContent();
+};
+SCWeb.core.ComponentManager.appendComponentInitialize(Example.DrawComponent);

--- a/plain-text-interface/plain_text/src/plain_text-paintPanel.js
+++ b/plain-text-interface/plain_text/src/plain_text-paintPanel.js
@@ -1,0 +1,156 @@
+/**
+ * Paint panel.
+ */
+
+Example.PaintPanel = function (containerId) {
+	this.containerId = containerId;
+};
+
+Example.PaintPanel.prototype = {
+
+	init: function () {
+		this._callPlainTextRepresentationAgent(this.containerId);
+	},
+	
+	/* Call agent of searching semantic neighborhood,
+	send ui_main_menu node as parameter and add it in web window history
+	*/
+	_callPlainTextRepresentationAgent: function (containerId) {
+		var container = $('#' + containerId);
+		var self = this;
+		//Resolve sc-addr of current language
+		var lang = $('#language-select').find(":selected")[0].attributes['sc_addr'].value;
+		// Resolve sc-addr of question
+		var question = $('#history-items a').first().attr("sc_addr");
+		// Find sc-addr of the question argument
+		window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_3F_A_A, [
+			question,
+			sc_type_arc_pos_const_perm,
+			sc_type_node]).
+			done(function (it) {
+				var question_arg = it[0][2];
+				console.log('question_arg: ' + question_arg);
+				// Resolve sc-addr of ui_menu_plain_text_representation node
+				SCWeb.core.Server.resolveScAddr(["ui_menu_plain_text_representation"],
+					function (data) {
+						// Get command of ui_menu_plain_text_representation
+						var cmd = data["ui_menu_plain_text_representation"];
+						console.log('ui_menu_plain_text_representation: ' + cmd);
+						// Simulate click on ui_menu_plain_text_representation button
+						SCWeb.core.Server.doCommand(cmd,
+							[question_arg, lang], function (plain_text_result) {
+
+								console.log("inDoCommand");
+
+								var result_question_node = plain_text_result.question;
+								console.log('result_question_node: ' + result_question_node);
+
+
+								setTimeout(function () {
+									// Some sleep
+									console.log('sleep');
+									// Resolve sc-addr of nrel_answer
+									SCWeb.core.Server.resolveScAddr(['nrel_answer'], function (keynodes) {
+										var nrel_answer_addr = keynodes['nrel_answer'];
+										console.log('nrel_answer_addr: ' + nrel_answer_addr);
+										// Get answer node from iter
+										window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_5F_A_A_A_F, [
+											result_question_node,
+											sc_type_arc_common | sc_type_const,
+											sc_type_node,
+											sc_type_arc_pos_const_perm,
+											nrel_answer_addr])
+											.done(function (iter) {
+												console.log('Iterator: ' + iter);
+
+												var answer = iter[0][2];
+												console.log('AnswerLink: ' + answer);
+
+												// Get content from answer
+												window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_3F_A_A, [
+													answer,
+													sc_type_arc_pos_const_perm,
+													sc_type_link])
+													.done(function (it3) {
+														console.log('it3 found');
+														var answ_cont = it3[0][2];
+
+														window.sctpClient.get_link_content(answ_cont, 'string')
+															.done(function (content) {
+																console.log('Content found');
+																// console.log(content);
+
+																// Add style to content
+																content = self._addStyleToContent(content);
+																// Add sc-addr for sc-elements in content
+																content = self._addScAddrsToContent(content, container);
+																// Add content to container
+																// console.log(content);
+																// container.append(content);
+															})//done content
+															.fail(function () {
+																console.log('fail to get content');
+															})//fail content
+													})//done it3
+													.fail(function () {
+														console.log('fail to find it3');
+													});//fail it3
+											})//done iter
+											.fail(function () {
+												console.log('fail to find iter');
+											});//fail iter
+									});//resolve nrel_answer
+								}, 1000);//timeout
+							});//SCWeb.core.Server.doCommand
+					});//SCWeb.core.Server.resolveScAddr
+			});//done
+	},//_callPlainTextRepresentationAgent
+
+	_addStyleToContent: function(content){
+		content = '<div><style>P {max-width: 700px;} LI{max-width: 700px;}</style>'
+			+ content + '</div>';
+		return content;
+	},
+
+	_addScAddrsToContent: function(content, container){
+		console.log('in_addScAddrsToContent');
+
+		// Create DocumentFragment from html content
+		var parser = new DOMParser();
+		var doc_fragment = parser.parseFromString(content, "text/html");
+
+		// Get list of sc_elements
+		var elements = doc_fragment.getElementsByTagName('sc_element');
+		console.log('elements.length: ' + elements.length);
+		var i;
+
+		$.each( elements, function( i, value ){
+			var element = elements[i];
+			console.log('sc_element[' + i + ']: ' + element.innerHTML);
+
+			// Resolve sc_addr of element
+			var idtf = element.getAttribute('sys_idtf');
+			console.log('idtf: ' + idtf);
+			SCWeb.core.Server.resolveScAddr([idtf], function (keynodes) {
+				var element_sc_addr = '' + keynodes[idtf];
+				// console.log('element_sc_addr: ' + element_sc_addr);
+				// Add sc_addr attribute
+				element.setAttribute('sc_addr', element_sc_addr);
+				// console.log('added: ' + element.getAttribute('sc_addr'));
+				$(element).css("text-decoration", "underline");
+			});
+		});
+
+		setTimeout(function () {
+
+			// Update content
+			var temporary_div = document.createElement('temporary_div');
+			temporary_div.appendChild( doc_fragment.documentElement.cloneNode(true) );
+			content = temporary_div.innerHTML;
+			console.log('content after adding sc_addr');
+			console.log(content);
+			container.append(content);
+			// document.removeChild(temporary_div);
+		}, 1000);//timeout
+	}
+}

--- a/plain-text-interface/plain_text/static/components/js/plain_text/plain_text.js
+++ b/plain-text-interface/plain_text/static/components/js/plain_text/plain_text.js
@@ -1,0 +1,265 @@
+var Example = {};
+
+function extend(child, parent) {
+    var F = function () {
+    };
+    F.prototype = parent.prototype;
+    child.prototype = new F();
+    child.prototype.constructor = child;
+    child.superclass = parent.prototype;
+}
+
+/**
+ * Example component.
+ */
+Example.DrawComponent = {
+    ext_lang: 'plain_text',
+    formats: ['format_plain_text'],
+    struct_support: true,
+    factory: function (sandbox) {
+        return new Example.DrawWindow(sandbox);
+    }
+};
+
+Example.DrawWindow = function (sandbox) {
+    this.sandbox = sandbox;
+    this.paintPanel = new Example.PaintPanel(this.sandbox.container);
+    this.paintPanel.init();
+    this.recieveData = function (data) {
+        console.log("in recieve data" + data);
+    };
+
+    var scElements = {};
+
+    function drawAllElements() {
+        var dfd = new jQuery.Deferred();
+       // for (var addr in scElements) {
+            jQuery.each(scElements, function(j, val){
+                var obj = scElements[j];
+                if (!obj || obj.translated) return;
+// check if object is an arc
+                if (obj.data.type & sc_type_arc_pos_const_perm) {
+                    var begin = obj.data.begin;
+                    var end = obj.data.end;
+                    // logic for component update should go here
+                }
+
+        });
+        SCWeb.ui.Locker.hide();
+        dfd.resolve();
+        return dfd.promise();
+    }
+
+// resolve keynodes
+    var self = this;
+    this.needUpdate = false;
+    this.requestUpdate = function () {
+        var updateVisual = function () {
+// check if object is an arc
+            var dfd1 = drawAllElements();
+            dfd1.done(function (r) {
+                return;
+            });
+
+
+/// @todo: Don't update if there are no new elements
+            window.clearTimeout(self.structTimeout);
+            delete self.structTimeout;
+            if (self.needUpdate)
+                self.requestUpdate();
+            return dfd1.promise();
+        };
+        self.needUpdate = true;
+        if (!self.structTimeout) {
+            self.needUpdate = false;
+            SCWeb.ui.Locker.show();
+            self.structTimeout = window.setTimeout(updateVisual, 1000);
+        }
+    }
+    
+    this.eventStructUpdate = function (added, element, arc) {
+        window.sctpClient.get_arc(arc).done(function (r) {
+            var addr = r[1];
+            window.sctpClient.get_element_type(addr).done(function (t) {
+                var type = t;
+                var obj = new Object();
+                obj.data = new Object();
+                obj.data.type = type;
+                obj.data.addr = addr;
+                if (type & sc_type_arc_mask) {
+                    window.sctpClient.get_arc(addr).done(function (a) {
+                        obj.data.begin = a[0];
+                        obj.data.end = a[1];
+                        scElements[addr] = obj;
+                        self.requestUpdate();
+                    });
+                }
+            });
+        });
+    };
+// delegate event handlers
+    this.sandbox.eventDataAppend = $.proxy(this.receiveData, this);
+    this.sandbox.eventStructUpdate = $.proxy(this.eventStructUpdate, this);
+    this.sandbox.updateContent();
+};
+SCWeb.core.ComponentManager.appendComponentInitialize(Example.DrawComponent);
+/**
+ * Paint panel.
+ */
+
+Example.PaintPanel = function (containerId) {
+	this.containerId = containerId;
+};
+
+Example.PaintPanel.prototype = {
+
+	init: function () {
+		this._initMarkup(this.containerId);
+	},
+
+	_initMarkup: function (containerId) {
+		this._callPlainTextRepresentationAgent(containerId);
+	},
+
+	/* Call agent of searching semantic neighborhood,
+	send ui_main_menu node as parameter and add it in web window history
+	*/
+	_callPlainTextRepresentationAgent: function (containerId) {
+		var container = $('#' + containerId);
+		var self = this;
+		//Resolve sc-addr of current language
+		var lang = $('#language-select').find(":selected")[0].attributes['sc_addr'].value;
+		// Resolve sc-addr of question
+		var question = $('#history-items a').first().attr("sc_addr");
+		// Find sc-addr of the question argument
+		window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_3F_A_A, [
+			question,
+			sc_type_arc_pos_const_perm,
+			sc_type_node]).
+			done(function (it) {
+				var question_arg = it[0][2];
+				console.log('question_arg: ' + question_arg);
+				// Resolve sc-addr of ui_menu_plain_text_representation node
+				SCWeb.core.Server.resolveScAddr(["ui_menu_plain_text_representation"],
+					function (data) {
+						// Get command of ui_menu_plain_text_representation
+						var cmd = data["ui_menu_plain_text_representation"];
+						console.log('ui_menu_plain_text_representation: ' + cmd);
+						// Simulate click on ui_menu_plain_text_representation button
+						SCWeb.core.Server.doCommand(cmd,
+							[question_arg, lang], function (plain_text_result) {
+
+								console.log("inDoCommand");
+
+								var result_question_node = plain_text_result.question;
+								console.log('result_question_node: ' + result_question_node);
+
+
+								setTimeout(function () {
+									// Some sleep
+									console.log('sleep');
+									// Resolve sc-addr of nrel_answer
+									SCWeb.core.Server.resolveScAddr(['nrel_answer'], function (keynodes) {
+										var nrel_answer_addr = keynodes['nrel_answer'];
+										console.log('nrel_answer_addr: ' + nrel_answer_addr);
+										// Get answer node from iter
+										window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_5F_A_A_A_F, [
+											result_question_node,
+											sc_type_arc_common | sc_type_const,
+											sc_type_node,
+											sc_type_arc_pos_const_perm,
+											nrel_answer_addr])
+											.done(function (iter) {
+												console.log('Iterator: ' + iter);
+
+												var answer = iter[0][2];
+												console.log('AnswerLink: ' + answer);
+
+												// Get content from answer
+												window.sctpClient.iterate_elements(SctpIteratorType.SCTP_ITERATOR_3F_A_A, [
+													answer,
+													sc_type_arc_pos_const_perm,
+													sc_type_link])
+													.done(function (it3) {
+														console.log('it3 found');
+														var answ_cont = it3[0][2];
+
+														window.sctpClient.get_link_content(answ_cont, 'string')
+															.done(function (content) {
+																console.log('Content found');
+																// console.log(content);
+
+																// Add style to content
+																content = self._addStyleToContent(content);
+																// Add sc-addr for sc-elements in content
+																content = self._addScAddrsToContent(content, container);
+																// Add content to container
+																// console.log(content);
+																// container.append(content);
+															})//done content
+															.fail(function () {
+																console.log('fail to get content');
+															})//fail content
+													})//done it3
+													.fail(function () {
+														console.log('fail to find it3');
+													});//fail it3
+											})//done iter
+											.fail(function () {
+												console.log('fail to find iter');
+											});//fail iter
+									});//resolve nrel_answer
+								}, 1000);//timeout
+							});//SCWeb.core.Server.doCommand
+					});//SCWeb.core.Server.resolveScAddr
+			});//done
+	},//_callPlainTextRepresentationAgent
+
+	_addStyleToContent: function(content){
+		content = '<div><style>P {max-width: 700px;} LI{max-width: 700px;}</style>'
+			+ content + '</div>';
+		return content;
+	},
+
+	_addScAddrsToContent: function(content, container){
+		console.log('in_addScAddrsToContent');
+
+		// Create DocumentFragment from html content
+		var parser = new DOMParser();
+		var doc_fragment = parser.parseFromString(content, "text/html");
+
+		// Get list of sc_elements
+		var elements = doc_fragment.getElementsByTagName('sc_element');
+		console.log('elements.length: ' + elements.length);
+		var i;
+
+		$.each( elements, function( i, value ){
+			var element = elements[i];
+			console.log('sc_element[' + i + ']: ' + element.innerHTML);
+
+			// Resolve sc_addr of element
+			var idtf = element.getAttribute('sys_idtf');
+			console.log('idtf: ' + idtf);
+			SCWeb.core.Server.resolveScAddr([idtf], function (keynodes) {
+				var element_sc_addr = '' + keynodes[idtf];
+				// console.log('element_sc_addr: ' + element_sc_addr);
+				// Add sc_addr attribute
+				element.setAttribute('sc_addr', element_sc_addr);
+				// console.log('added: ' + element.getAttribute('sc_addr'));
+				$(element).css("text-decoration", "underline");
+			});
+		});
+
+		setTimeout(function () {
+
+			// Update content
+			var temporary_div = document.createElement('temporary_div');
+			temporary_div.appendChild( doc_fragment.documentElement.cloneNode(true) );
+			content = temporary_div.innerHTML;
+			console.log('content after adding sc_addr');
+			console.log(content);
+			container.append(content);
+			// document.removeChild(temporary_div);
+		}, 1000);//timeout
+	}
+}

--- a/problem-solver/cxx/exampleModule/CMakeLists.txt
+++ b/problem-solver/cxx/exampleModule/CMakeLists.txt
@@ -4,12 +4,14 @@ set(SOURCES
 		"exampleModule.cpp"
 		"keynodes/keynodes.cpp"
 		"agents/SubdividingSearchAgent.cpp"
+		"agents/PlainTextRepresentationAgent.cpp"
 		)
 
 set(HEADERS
 		"exampleModule.hpp"
 		"keynodes/keynodes.hpp"
 		"agents/SubdividingSearchAgent.hpp"
+		"agents/PlainTextRepresentationAgent.hpp"
 		)
 
 include_directories(${SC_EXAMPLE_MODULE_SRC} ${SC_MEMORY_SRC} ${GLIB2_INCLUDE_DIRS})

--- a/problem-solver/cxx/exampleModule/agents/PlainTextRepresentationAgent.cpp
+++ b/problem-solver/cxx/exampleModule/agents/PlainTextRepresentationAgent.cpp
@@ -1,0 +1,357 @@
+/*
+* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+* Distributed under the MIT License
+* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+*/
+
+#include <sc-memory/cpp/sc_stream.hpp>
+#include <sc-kpm/sc-agents-common/utils/IteratorUtils.hpp>
+#include <sc-kpm/sc-agents-common/utils/AgentUtils.hpp>
+
+#include <sc-memory/cpp/sc_link.hpp>
+#include <map>
+#include <iostream>
+
+#include "PlainTextRepresentationAgent.hpp"
+#include "keynodes/keynodes.hpp"
+
+using namespace std;
+using namespace utils;
+
+typedef string (exampleModule::PlainTextRepresentationAgent::*Mapper)(const ScAddr &, const ScAddr&);
+
+namespace exampleModule
+{
+    SC_AGENT_IMPLEMENTATION(PlainTextRepresentationAgent)
+    {
+        if (!edgeAddr.IsValid())
+            return SC_RESULT_ERROR;
+        ScAddr questionNode = ms_context->GetEdgeTarget(edgeAddr);
+        ScAddr param = IteratorUtils::getFirstByOutRelation(ms_context.get(), questionNode, Keynodes::rrel_1);
+        ScAddr language = IteratorUtils::getFirstByOutRelation(ms_context.get(), questionNode, Keynodes::rrel_2);
+        if (!param.IsValid())
+            return SC_RESULT_ERROR_INVALID_PARAMS;
+
+        if (!language.IsValid())
+            language = Keynodes::lang_en;
+
+        ScAddr answer = ms_context->CreateNode(ScType::NodeConstStruct);
+
+        Mapper mappers[6] = {
+            &exampleModule::PlainTextRepresentationAgent::mapMainIdtf,
+            &exampleModule::PlainTextRepresentationAgent::mapIdtf,
+            &exampleModule::PlainTextRepresentationAgent::mapDefinition,
+            &exampleModule::PlainTextRepresentationAgent::mapStatement,
+            &exampleModule::PlainTextRepresentationAgent::mapClassification,
+            &exampleModule::PlainTextRepresentationAgent::mapExample
+        };
+
+        string result = "";
+        for (int i = 0; i < 6; i++)
+        {
+            string mappingRes = (this->*mappers[i])(param, language);
+            if (mappingRes != "")
+                result += mappingRes;
+        }
+        ScAddr newLink;
+        createLinkByContent(result, newLink);
+
+        ms_context->CreateEdge(ScType::EdgeAccessConstPosPerm, answer, newLink);
+        AgentUtils::finishAgentWork(ms_context.get(), questionNode, answer);
+        return SC_RESULT_OK;
+    }
+
+    void PlainTextRepresentationAgent::createLinkByContent(const string &str, ScAddr &newLink)
+    {
+        size_t size = str.size();
+        auto *wordChar = new sc_char[size];
+        strcpy(wordChar, str.c_str());
+        ScStream streamLink(wordChar, size, SC_STREAM_FLAG_READ);
+        newLink = ms_context->CreateLink();
+        ms_context->SetLinkContent(newLink, streamLink);
+    }
+
+    ScTemplateSearchResult PlainTextRepresentationAgent::templateSearchForDefOrStat(const ScAddr &mainEntity,
+            const ScAddr &language, const ScAddr &type, const string templName)
+    {
+        ScTemplate templ;
+
+        templ.Triple(
+                type,
+                ScType::EdgeAccessVarPosPerm,
+                ScType::NodeVar >> "_node");
+        templ.Triple(
+                "_node",
+                ScType::EdgeAccessVarPosPerm >> "_edge_pos",
+                mainEntity);
+        templ.Triple(
+                Keynodes::rrel_key_sc_element,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_pos");
+        templ.Triple(
+                ScType::NodeVar >> "_text_translation_node",
+                ScType::EdgeDCommonVar >> "_edge_translation",
+                "_node");
+        templ.Triple(
+                Keynodes::nrel_sc_text_translation,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_translation");
+        templ.Triple(
+                "_text_translation_node",
+                ScType::EdgeAccessVarPosPerm,
+                ScType::Link >> templName);
+        templ.Triple(
+                language,
+                ScType::EdgeAccessVarPosPerm,
+                templName);
+
+        ScTemplateSearchResult results;
+        ms_context->HelperSearchTemplate(templ, results);
+        return results;
+    }
+
+    ScTemplateSearchResult PlainTextRepresentationAgent::templateSearchForIdtf(const ScAddr &mainEntity,
+                                                                                    const ScAddr &language, const ScAddr &type, const string templName)
+    {
+        ScTemplate templ;
+        templ.Triple(
+                mainEntity,
+                ScType::EdgeDCommonVar >> "_edge_idtf",
+                ScType::Link >> templName);
+        templ.Triple(
+                type,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_idtf");
+        templ.Triple(
+                language,
+                ScType::EdgeAccessVarPosPerm,
+                templName);
+
+        ScTemplateSearchResult results;
+        ms_context->HelperSearchTemplate(templ, results);
+        return results;
+    }
+
+    string PlainTextRepresentationAgent::mapMainIdtf(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        string mainIdtf = getMainIdtf(mainEntity, language);
+        string systIdtfOfClass = getSystemIdtf(mainEntity);
+
+        return "<b><sc_element sys_idtf  = \"" +  systIdtfOfClass + "\">" + mainIdtf + "</sc_element></b> ";
+    }
+
+    string PlainTextRepresentationAgent::mapIdtf(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        string templName = "_link";
+        ScTemplateSearchResult results = templateSearchForIdtf(mainEntity, language, Keynodes::nrel_idtf, templName);
+
+        if (results.Size() == 0)
+            return ""; //no idtf
+
+        string mappingResult = "";
+        if (language == Keynodes::lang_en)
+            mappingResult += "<p>Alternative names: ";
+        else
+            mappingResult += "<p>Альтернативные названия: ";
+
+        for (size_t a = 0; a < results.Size(); a++)
+        {
+            mappingResult += getLinkContent(results[a][templName]);
+            if(a != results.Size() - 1)
+                mappingResult += ", ";
+            else
+                mappingResult += "</p>";
+        }
+        return mappingResult;
+    }
+
+    string PlainTextRepresentationAgent::mapStatement(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        string templName = "_link_statement";
+        ScTemplateSearchResult results = templateSearchForDefOrStat(mainEntity, language, Keynodes::statement, templName);
+
+        if (results.Size() == 0)
+            return ""; //no statements
+
+        string mappingResult = "";
+        for (size_t a = 0; a < results.Size(); a++)
+        {
+            string statement = getLinkContent(results[a][templName]);
+            mappingResult += "<p>" + statement + "</p>";
+        }
+        return mappingResult;
+    }
+
+    string PlainTextRepresentationAgent::mapDefinition(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        string templName = "_link_definition";
+        ScTemplateSearchResult results = templateSearchForDefOrStat(mainEntity, language, Keynodes::definition, templName);
+
+        if (results.Size() == 0)
+            return ""; //no definitions
+
+        string mappingResult = "";
+        if (language == Keynodes::lang_en)
+            mappingResult += "<p>Definition</p>: ";
+        else
+            mappingResult += "<p>Определение</p>: ";
+
+        for (size_t a = 0; a < results.Size(); a++)
+        {
+            string definition = getLinkContent(results[a][templName]);
+            mappingResult += "<p><span style=\"border: 4px double black\">" + definition + "</span></p>";
+        }
+        return mappingResult;
+    }
+
+    string PlainTextRepresentationAgent::mapClassification(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        map<string, vector<ScAddr>> classificationGroups;
+
+        ScTemplate templ;
+        templ.Triple(
+                ScType::NodeVar >> "_tuple",
+                ScType::EdgeDCommonVar >> "_edge_subdividing",
+                mainEntity);
+        templ.Triple(
+                Keynodes::nrel_subdividing,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_subdividing");
+        templ.Triple(
+                "_tuple",
+                ScType::EdgeAccessVarPosPerm,
+                ScType::NodeVarClass >> "_class");
+
+        ScTemplateSearchResult results;
+        ms_context->HelperSearchTemplate(templ, results);
+
+        if (results.Size() == 0)
+            return ""; //no subdividing
+
+        for (size_t a = 0; a < results.Size(); a++)
+        {
+            string mainIdtfOfGroup = getMainIdtf(results[a]["_tuple"], language);
+            if (mainIdtfOfGroup == "")
+                mainIdtfOfGroup = "";
+            classificationGroups[mainIdtfOfGroup].push_back(results[a]["_class"]);
+        }
+
+        string mappingResult = "";
+        if (language == Keynodes::lang_en)
+            mappingResult += "<p><b>Classification: </b></p>";
+        else
+            mappingResult += "<p><b>Классификация: </b></p>";
+
+        for (map<string, vector<ScAddr>>::iterator it = classificationGroups.begin(); it != classificationGroups.end(); it++)
+        {
+            if (!(it->first == ""))
+                mappingResult += "<p>" + it->first + ": </p>";
+            for (size_t i = 0; i < (it->second).size(); i++)
+            {
+                string systIdtfOfClass = getSystemIdtf(it->second[i]);
+                string mainIdtf = getMainIdtf(it->second[i], language);
+
+                mappingResult += "<li><sc_element sys_idtf  = \"" + systIdtfOfClass + "\">" + mainIdtf + "</sc_element></li>";
+            }
+        }
+        return mappingResult;
+    }
+
+    string PlainTextRepresentationAgent::mapExample(const ScAddr &mainEntity, const ScAddr &language)
+    {
+        ScTemplate templ;
+        templ.Triple(
+                ScType::NodeVar >> "_node",
+                ScType::EdgeAccessVarPosPerm >> "_edge_pos",
+                mainEntity);
+        templ.Triple(
+                Keynodes::rrel_key_sc_element,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_pos");
+        templ.Triple(
+                ScType::NodeVar >> "_text_translation_node",
+                ScType::EdgeDCommonVar >> "_edge_translation",
+                "_node");
+        templ.Triple(
+                Keynodes::nrel_sc_text_translation,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_translation");
+        templ.Triple(
+                "_text_translation_node",
+                ScType::EdgeAccessVarPosPerm >> "_edge_example",
+                ScType::Link >> "_link");
+        templ.Triple(
+                Keynodes::rrel_example,
+                ScType::EdgeAccessVarPosPerm,
+                "_edge_example");
+        templ.Triple(
+                language,
+                ScType::EdgeAccessVarPosPerm,
+                "_link");
+
+        ScTemplateSearchResult results;
+        ms_context->HelperSearchTemplate(templ, results);
+
+        if (results.Size() == 0)
+            return ""; //no examples
+
+        string mappingResult = "";
+        if (language == Keynodes::lang_en)
+            mappingResult += "<p>Examples: </p>: ";
+        else
+            mappingResult += "<p>Примеры: </p>: ";
+
+        for (size_t a = 0; a < results.Size(); a++)
+        {
+            string example = getLinkContent(results[a]["_link"]);
+            mappingResult += "<p>" + example + "</p>";
+        }
+        return mappingResult;
+    }
+
+    string PlainTextRepresentationAgent::getMainIdtf(const ScAddr &entity, const ScAddr &language)
+    {
+        string templName = "_link";
+        ScTemplateSearchResult results = templateSearchForIdtf(entity, language, Keynodes::nrel_main_idtf, templName);
+
+        if (results.Size() == 0)
+            return ""; //no main idtf
+
+        return getLinkContent(results[0][templName]);
+    }
+
+    string PlainTextRepresentationAgent::getLinkContent(const ScAddr &link)
+    {
+        ScStream stream;
+        try
+        {
+            ms_context->GetLinkContent(link, stream);
+        }
+        catch (...)
+        {
+            return "";
+        }
+
+        size_t size = stream.Size();
+        auto *text = new sc_char[size + 1];
+        stream.Read(text, size, size);
+        text[size] = '\0';
+        text[0] = toupper(text[0]);
+        string res(text);
+
+        return res;
+    }
+
+    string PlainTextRepresentationAgent::getSystemIdtf(const ScAddr &entity)
+    {
+        try
+        {
+            return ms_context->HelperGetSystemIdtf(entity);
+        }
+        catch (...)
+        {
+            return "";
+        }
+    }
+
+} // namespace exampleModule

--- a/problem-solver/cxx/exampleModule/agents/PlainTextRepresentationAgent.hpp
+++ b/problem-solver/cxx/exampleModule/agents/PlainTextRepresentationAgent.hpp
@@ -1,0 +1,38 @@
+/*
+* This source file is part of an OSTIS project. For the latest info, see http://ostis.net
+* Distributed under the MIT License
+* (See accompanying file COPYING.MIT or copy at http://opensource.org/licenses/MIT)
+*/
+
+#pragma once
+
+#include <sc-memory/cpp/kpm/sc_agent.hpp>
+
+#include "keynodes/keynodes.hpp"
+#include "PlainTextRepresentationAgent.generated.hpp"
+
+namespace exampleModule
+{
+
+class PlainTextRepresentationAgent : public ScAgent
+{
+  SC_CLASS(Agent, Event(Keynodes::question_plain_text_representation, ScEvent::Type::AddOutputEdge))
+  SC_GENERATED_BODY()
+
+private:
+    void createLinkByContent(const string & str, ScAddr &newLink);
+    string getLinkContent(const ScAddr & link);
+    string mapMainIdtf(const ScAddr &mainEntity, const ScAddr &language);
+    string mapIdtf(const ScAddr &mainEntity, const ScAddr &language);
+    string mapStatement(const ScAddr &mainEntity, const ScAddr &language);
+    string mapDefinition(const ScAddr &mainEntity, const ScAddr &language);
+    string mapClassification(const ScAddr &mainEntity, const ScAddr &language);
+    string mapExample(const ScAddr &mainEntity, const ScAddr &language);
+    string getMainIdtf(const ScAddr &entity, const ScAddr &language);
+    string getSystemIdtf(const ScAddr &entity);
+    ScTemplateSearchResult templateSearchForDefOrStat(const ScAddr &mainEntity, const ScAddr &language, const ScAddr &type, const string templName);
+    ScTemplateSearchResult templateSearchForIdtf(const ScAddr &mainEntity, const ScAddr &language, const ScAddr &type, const string templName);
+
+};
+
+} // namespace exampleModule

--- a/problem-solver/cxx/exampleModule/exampleModule.cpp
+++ b/problem-solver/cxx/exampleModule/exampleModule.cpp
@@ -7,6 +7,7 @@
 #include "exampleModule.hpp"
 #include "keynodes/keynodes.hpp"
 #include "agents/SubdividingSearchAgent.hpp"
+#include "agents/PlainTextRepresentationAgent.hpp"
 
 using namespace exampleModule;
 
@@ -18,6 +19,7 @@ sc_result ExampleModule::InitializeImpl()
     return SC_RESULT_ERROR;
 
   SC_AGENT_REGISTER(SubdividingSearchAgent)
+  SC_AGENT_REGISTER(PlainTextRepresentationAgent)
 
   return SC_RESULT_OK;
 }
@@ -25,6 +27,7 @@ sc_result ExampleModule::InitializeImpl()
 sc_result ExampleModule::ShutdownImpl()
 {
   SC_AGENT_UNREGISTER(SubdividingSearchAgent)
+  SC_AGENT_UNREGISTER(PlainTextRepresentationAgent)
 
   return SC_RESULT_OK;
 }

--- a/problem-solver/cxx/exampleModule/keynodes/keynodes.cpp
+++ b/problem-solver/cxx/exampleModule/keynodes/keynodes.cpp
@@ -12,12 +12,27 @@ namespace exampleModule
 {
 
 ScAddr Keynodes::question_find_subdividing;
+ScAddr Keynodes::question_message_classification;
+ScAddr Keynodes::question_plain_text_representation;
+ScAddr Keynodes::lang_ru;
+ScAddr Keynodes::lang_en;
+ScAddr Keynodes::nrel_main_idtf;
+ScAddr Keynodes::nrel_idtf;
+ScAddr Keynodes::rrel_example;
+ScAddr Keynodes::nrel_subdividing;
+ScAddr Keynodes::nrel_plain_text_representation;
+ScAddr Keynodes::rrel_key_sc_element;
+ScAddr Keynodes::definition;
+ScAddr Keynodes::statement;
+
 ScAddr Keynodes::nrel_sc_text_translation;
-ScAddr Keynodes::rrel_standard;
-ScAddr Keynodes::nrel_paradigm;
-ScAddr Keynodes::undefined_word;
-ScAddr Keynodes::nrel_text_decomposition;
+ScAddr Keynodes::nrel_concatenation;
 ScAddr Keynodes::rrel_1;
-ScAddr Keynodes::nrel_sequence;
+ScAddr Keynodes::rrel_2;
+ScAddr Keynodes::nrel_paradigm;
+ScAddr Keynodes::concept_lexeme;
+ScAddr Keynodes::nrel_intersection;
+ScAddr Keynodes::concept_tokens_category;
+ScAddr Keynodes::nrel_message_key_elements;
 
 }

--- a/problem-solver/cxx/exampleModule/keynodes/keynodes.hpp
+++ b/problem-solver/cxx/exampleModule/keynodes/keynodes.hpp
@@ -20,30 +20,72 @@ class Keynodes : public ScObject
   SC_GENERATED_BODY()
 
 public:
+    SC_PROPERTY(Keynode("question_find_subdividing"), ForceCreate)
+    static ScAddr question_find_subdividing;
 
-  SC_PROPERTY(Keynode("question_find_subdividing"), ForceCreate)
-  static ScAddr question_find_subdividing;
+    SC_PROPERTY(Keynode("question_message_classification"), ForceCreate)
+    static ScAddr question_message_classification;
 
-  SC_PROPERTY(Keynode("nrel_sc_text_translation"), ForceCreate)
-  static ScAddr nrel_sc_text_translation;
+    SC_PROPERTY(Keynode("question_plain_text_representation"), ForceCreate)
+    static ScAddr question_plain_text_representation;
 
-  SC_PROPERTY(Keynode("rrel_standard"), ForceCreate)
-  static ScAddr rrel_standard;
+    SC_PROPERTY(Keynode("lang_ru"), ForceCreate)
+    static ScAddr lang_ru;
 
-  SC_PROPERTY(Keynode("nrel_paradigm"), ForceCreate)
-  static ScAddr nrel_paradigm;
+    SC_PROPERTY(Keynode("lang_en"), ForceCreate)
+    static ScAddr lang_en;
 
-  SC_PROPERTY(Keynode("undefined_word"), ForceCreate)
-  static ScAddr undefined_word;
+    SC_PROPERTY(Keynode("nrel_main_idtf"), ForceCreate)
+    static ScAddr nrel_main_idtf;
 
-  SC_PROPERTY(Keynode("nrel_text_decomposition"), ForceCreate)
-  static ScAddr nrel_text_decomposition;
+    SC_PROPERTY(Keynode("nrel_idtf"), ForceCreate)
+    static ScAddr nrel_idtf;
 
-  SC_PROPERTY(Keynode("rrel_1"), ForceCreate)
-  static ScAddr rrel_1;
+    SC_PROPERTY(Keynode("rrel_example"), ForceCreate)
+    static ScAddr rrel_example;
 
-  SC_PROPERTY(Keynode("nrel_sequence"), ForceCreate)
-  static ScAddr nrel_sequence;
+    SC_PROPERTY(Keynode("rrel_key_sc_element"), ForceCreate)
+    static ScAddr rrel_key_sc_element;
+
+    SC_PROPERTY(Keynode("definition"), ForceCreate)
+    static ScAddr definition;
+
+    SC_PROPERTY(Keynode("statement"), ForceCreate)
+    static ScAddr statement;
+
+    SC_PROPERTY(Keynode("nrel_subdividing"), ForceCreate)
+    static ScAddr nrel_subdividing;
+
+    SC_PROPERTY(Keynode("nrel_plain_text_representation"), ForceCreate)
+    static ScAddr nrel_plain_text_representation;
+
+    SC_PROPERTY(Keynode("nrel_sc_text_translation"), ForceCreate)
+    static ScAddr nrel_sc_text_translation;
+
+    SC_PROPERTY(Keynode("nrel_concatenation"), ForceCreate)
+    static ScAddr nrel_concatenation;
+
+    SC_PROPERTY(Keynode("rrel_1"), ForceCreate)
+    static ScAddr rrel_1;
+
+    SC_PROPERTY(Keynode("rrel_2"), ForceCreate)
+    static ScAddr rrel_2;
+
+    SC_PROPERTY(Keynode("concept_lexeme"), ForceCreate)
+    static ScAddr concept_lexeme;
+
+    SC_PROPERTY(Keynode("nrel_paradigm"), ForceCreate)
+    static ScAddr nrel_paradigm;
+
+    SC_PROPERTY(Keynode("nrel_intersection"), ForceCreate)
+    static ScAddr nrel_intersection;
+
+    SC_PROPERTY(Keynode("concept_tokens_category"), ForceCreate)
+    static ScAddr concept_tokens_category;
+
+    SC_PROPERTY(Keynode("nrel_message_key_elements"), ForceCreate)
+    static ScAddr nrel_message_key_elements;
+
 };
 
 } // namespace exampleModule

--- a/problem-solver/cxx/exampleModule/specifications/agent_of_plain_text_representation/lib_component_ui_menu_plain_text_representation.scs
+++ b/problem-solver/cxx/exampleModule/specifications/agent_of_plain_text_representation/lib_component_ui_menu_plain_text_representation.scs
@@ -1,0 +1,11 @@
+lib_component_ui_menu_plain_text_representation
+=> nrel_main_idtf:
+	[Компонент библиотеки. Команда пользовательского интерфейса отображения на естественном языке]
+	(* <- lang_ru;; *);
+	[Library component. User interfaces command of plain text representation]
+	(* <- lang_en;; *);
+
+<- library_of_platform_independent_reusable_components;
+<- library_of_atomic_reusable_components;;
+
+lib_component_ui_menu_plain_text_representation = [*^"file://ui_menu_plain_text_representation.scsi"*];;

--- a/problem-solver/cxx/exampleModule/specifications/agent_of_plain_text_representation/ui_menu_plain_text_representation.scsi
+++ b/problem-solver/cxx/exampleModule/specifications/agent_of_plain_text_representation/ui_menu_plain_text_representation.scsi
@@ -1,0 +1,30 @@
+ui_menu_plain_text_representation <- ui_user_command_class_atom; ui_user_command_class_view_kb; ui_two_argument_command_class;;
+
+ui_menu_plain_text_representation 
+=> nrel_main_idtf: 
+	[Каково отображение семантической окрестности сущности на естественном языке?]
+	(* <- lang_ru;; *);
+=> nrel_idtf: 
+	[Запрос на отображение семантической окрестности сущности на естественном языке]
+	(* <- lang_ru;; *);;
+
+ui_menu_plain_text_representation 
+=> nrel_main_idtf: 
+	[What is the natural language representation of the semantic neighborhood of an entity?]
+	(* <- lang_en;; *);
+=> nrel_idtf: 
+	[Request to represent the semantic neighborhood of an entity in natural language]
+	(* <- lang_en;; *);;
+
+ui_menu_plain_text_representation => ui_nrel_command_template:
+	[*
+		question_plain_text_representation _-> ._question_plain_text_representation_instance
+			(*
+				_-> rrel_1:: ui_arg_1;;
+				_-> rrel_2:: ui_arg_2;;
+			*);;
+		._question_plain_text_representation_instance _<- question;;
+	*];;
+
+ui_menu_plain_text_representation => ui_nrel_command_lang_template: [Каково отображение на естественном языке $ui_arg_2 семантической окрестности $ui_arg_1] (* <- lang_ru;; *);;
+ui_menu_plain_text_representation => ui_nrel_command_lang_template: [What is the natural language $ui_arg_2 representation of the semantic neighborhood of $ui_arg_1] (* <- lang_en;; *);;


### PR DESCRIPTION
Add **plain_text** - UI component for plain text representation.

*Author*: [Al-Kom](https://github.com/Al-Kom)


Add **PlainTextRepresentationAgent** - two-parameter agent for creating html-text based on base constructions.
 - selected language support.
 - working on templates.
